### PR TITLE
fix: Failed to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "@vue/cli-plugin-babel": "^3.0.5",
     "@vue/cli-plugin-eslint": "^3.0.5",
     "@vue/cli-service": "^3.0.5",
-    "vue-template-compiler": "^2.5.17"
+    "vue-template-compiler": "^2.5.17",
+    "core-js": "^2.6.5"
   },
   "napa": {
     "jquery.flot.animator": "https://github.com/Codicode/flotanimator.git#3c256c0183d713fd3bf41d04417873928eb1a751",


### PR DESCRIPTION
fix: Failed to compile

I get an error when I type "npm run serve".
```
This dependency was not found:
core-js/modules/es6.regexp.to-string in ./node_modules/cache-loader/dist/cjs.js??ref--12-0!./node_modules/babel-loader/lib!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./src/pages/Charts/Charts.vue?vue&type=script&lang=js&
```
Ref. https://github.com/flatlogic/sing-app-vue-dashboard/issues/3